### PR TITLE
Add Github Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,12 @@
+Before submitting an issue, please be sure to update to the latest Gem version
+
+### Describe the steps to reproduce
+
+### What did you expect to happen?
+
+### What happened instead?
+
+Paste in any error messages using [code-fences](https://help.github.com/articles/creating-and-highlighting-code-blocks/)
+
+### Additional information
+


### PR DESCRIPTION
Simplify the process of getting a good issue/bug report using github templates.

(Note: Github pull request templates are also possible.)