### PR TITLE
[Resolves #60] When setting up a new machine it might duplicate the project configuration

### DIFF
--- a/lib/story_branch/commands/add.rb
+++ b/lib/story_branch/commands/add.rb
@@ -28,6 +28,9 @@ module StoryBranch
       private
 
       def create_local_config
+        return if local_config_has_value?
+
+        puts "Appending #{project_id}"
         @local_config.append(project_id, to: :project_id)
         @local_config.write(force: true)
       end
@@ -43,6 +46,15 @@ module StoryBranch
 
         @project_id = prompt.ask "Please provide this project's id:"
         @project_id
+      end
+
+      def local_config_has_value?
+        config_value = @local_config.fetch(:project_id)
+        if config_value.is_a? Array
+          config_value.include?(project_id)
+        else
+          config_value == project_id
+        end
       end
     end
   end

--- a/spec/unit/add_spec.rb
+++ b/spec/unit/add_spec.rb
@@ -78,13 +78,68 @@ RSpec.describe StoryBranch::Commands::Add do
       expect(config.fetch('123456', :api_key)).to eq 'amazingkey'
     end
 
-    it 'appends to the local config file' do
-      config = TTY::Config.new
-      config.append_path('.')
-      config.filename = '.story_branch'
-      expect(config.persisted?).to eq true
-      config.read
-      expect(config.fetch(:project_id)).to eq %w[1234560000 123456]
+    describe 'when the local config does not have the project id' do
+      it 'appends to the local config file' do
+        config = TTY::Config.new
+        config.append_path('.')
+        config.filename = '.story_branch'
+        expect(config.persisted?).to eq true
+        config.read
+        expect(config.fetch(:project_id)).to eq %w[1234560000 123456]
+      end
+    end
+
+    describe 'when the local config already has the project id' do
+      let(:config_directory) do
+        FileUtils.mkdir_p Dir.home
+        config = TTY::Config.new
+        config.append_path(Dir.home)
+        config.filename = '.story_branch'
+        config.set('1234560000', :api_key, value: 'amazingkey0000')
+        config.write
+
+        local_config = TTY::Config.new
+        local_config.append_path('.')
+        local_config.filename = '.story_branch'
+        local_config.set(:project_id, value: '1234560000')
+        local_config.append('123456', to: :project_id)
+        local_config.write
+      end
+
+      it 'does nothing' do
+        config = TTY::Config.new
+        config.append_path('.')
+        config.filename = '.story_branch'
+        expect(config.persisted?).to eq true
+        config.read
+        expect(config.fetch(:project_id)).to eq %w[1234560000 123456]
+      end
+    end
+
+    describe 'when the local config only has that project id' do
+      let(:config_directory) do
+        FileUtils.mkdir_p Dir.home
+        config = TTY::Config.new
+        config.append_path(Dir.home)
+        config.filename = '.story_branch'
+        config.set('123456', :api_key, value: 'amazingkey')
+        config.write
+
+        local_config = TTY::Config.new
+        local_config.append_path('.')
+        local_config.filename = '.story_branch'
+        local_config.set(:project_id, value: '123456')
+        local_config.write
+      end
+
+      it 'does nothing' do
+        config = TTY::Config.new
+        config.append_path('.')
+        config.filename = '.story_branch'
+        expect(config.persisted?).to eq true
+        config.read
+        expect(config.fetch(:project_id)).to eq '123456'
+      end
     end
   end
 end


### PR DESCRIPTION
# Issue Title

- When setting up a new machine it might duplicate the project configuration

# Main changes

- Before adding a new project id check if it is already existing in the local configuration file

# Remove from here below if there is nothing to be added to the changelog
CHANGELOG
 - Fixes duplication of project ids in local story_branch file
--- 8< ---
