### PR TITLE
[Resolves #61] Story branch asks for choosing project unecessarily

### DIFF
--- a/lib/story_branch/main.rb
+++ b/lib/story_branch/main.rb
@@ -160,15 +160,14 @@ module StoryBranch
       return @project_id if @project_id
 
       project_ids = @local_config.fetch(:project_id)
+      @project_id = choose_project_id(project_ids)
+    end
 
-      @project_id = if project_ids.is_a? Array
-                      prompt.select(
-                        'Which project you want to fetch from?',
-                        project_ids
-                      )
-                    else
-                      project_ids
-                    end
+    def choose_project_id(project_ids)
+      return project_ids unless project_ids.is_a? Array
+      return project_ids[0] unless project_ids.length > 1
+
+      prompt.select('Which project you want to fetch from?', project_ids)
     end
 
     def api_key


### PR DESCRIPTION
# Issue Title

- Story branch asks for choosing project unecessarily

# Main changes

- Check if project id list is in an array structure and if its length is 1, then return the first element of the array. 

# Remove from here below if there is nothing to be added to the changelog
CHANGELOG
 - No longer need to choose project id if the yml config is in array format but only has 1 entry
--- 8< ---
