### PR TITLE
[Resolves #62] Need to remove `>` and `<` from story name before creating the branch

### DIFF
--- a/lib/story_branch/string_utils.rb
+++ b/lib/story_branch/string_utils.rb
@@ -15,7 +15,7 @@ module StoryBranch
     end
 
     def self.dashed(text)
-      sanitize(text).tr(" _,./:;+&'\"?<>", '-').squeeze('-').sub(/^-/, '').sub(/-$/, '')
+      sanitize(text).tr(" _,./:;+&'\"?<>", '-').squeeze('-').gsub(/-$|^-/, '')
     end
 
     def self.normalised_branch_name(text)

--- a/lib/story_branch/string_utils.rb
+++ b/lib/story_branch/string_utils.rb
@@ -3,8 +3,8 @@
 module StoryBranch
   # Utility class for string manipulation
   class StringUtils
-    def self.sanitize(s)
-      res = s.strip
+    def self.sanitize(text)
+      res = text.strip
       res.tr!("\n", '-')
       encoding_options = {
         invalid: :replace, # Replace invalid byte sequences
@@ -14,16 +14,16 @@ module StoryBranch
       res.encode(Encoding.find('ASCII'), encoding_options)
     end
 
-    def self.dashed(s)
-      sanitize(s).tr(" _,./:;+&'\"?", '-').squeeze('-')
+    def self.dashed(text)
+      sanitize(text).tr(" _,./:;+&'\"?<>", '-').squeeze('-').sub(/^-/, '').sub(/-$/, '')
     end
 
-    def self.normalised_branch_name(s)
-      dashed(s).downcase
+    def self.normalised_branch_name(text)
+      dashed(text).downcase
     end
 
-    def self.undashed(s)
-      s.tr('-', ' ').squeeze(' ').strip.capitalize
+    def self.undashed(text)
+      text.tr('-', ' ').squeeze(' ').strip.capitalize
     end
   end
 end

--- a/spec/unit/string_utils_spec.rb
+++ b/spec/unit/string_utils_spec.rb
@@ -5,12 +5,12 @@ require 'story_branch/string_utils'
 
 # rubocop:disable Metrics/BlockLength
 RSpec.describe StoryBranch::StringUtils do
-  let(:simple_string) { "H_e,l l::o.W;h+o&?'Are'" }
+  let(:simple_string) { "<H_e,l l::o.W;h+o&?'Are'>" }
 
   describe 'dashed' do
     it 'converts non alphabet to dash' do
       dashed = StoryBranch::StringUtils.dashed(simple_string)
-      expect(dashed).to eq 'H-e-l-l-o-W-h-o-Are-'
+      expect(dashed).to eq 'H-e-l-l-o-W-h-o-Are'
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe StoryBranch::StringUtils do
   describe 'normalised_branch_name' do
     it 'downcases the dashed string' do
       res = StoryBranch::StringUtils.normalised_branch_name(simple_string)
-      expect(res).to eq 'h-e-l-l-o-w-h-o-are-'
+      expect(res).to eq 'h-e-l-l-o-w-h-o-are'
     end
   end
 


### PR DESCRIPTION
# Issue Title

- Need to remove `>` and `<` from story name before creating the branch

# Main changes

- Added > and < to characters to remove when sanitising the string
- Removed extra - in the beginning and end of branch name

# Remove from here below if there is nothing to be added to the changelog
CHANGELOG
 - No more weird >/< in the branch names
 - No more branch names starting or ending with -
--- 8< ---
