### PR TITLE
[Resolves #70] branch name sanitisation should also exclude back ticks

### DIFF
--- a/lib/story_branch/string_utils.rb
+++ b/lib/story_branch/string_utils.rb
@@ -15,7 +15,7 @@ module StoryBranch
     end
 
     def self.dashed(text)
-      sanitize(text).tr(" _,./:;+&'\"?<>", '-').squeeze('-').gsub(/-$|^-/, '')
+      sanitize(text).gsub(/[^0-9a-z]/i, '-').squeeze('-').gsub(/-$|^-/, '')
     end
 
     def self.normalised_branch_name(text)

--- a/spec/unit/string_utils_spec.rb
+++ b/spec/unit/string_utils_spec.rb
@@ -5,12 +5,12 @@ require 'story_branch/string_utils'
 
 # rubocop:disable Metrics/BlockLength
 RSpec.describe StoryBranch::StringUtils do
-  let(:simple_string) { "<H_e,l l::o.W;h+o&?'Are'>" }
+  let(:simple_string) { "$%^*()<H_e,l l::o.W;h+o&?'A#r`e'>@" }
 
   describe 'dashed' do
     it 'converts non alphabet to dash' do
       dashed = StoryBranch::StringUtils.dashed(simple_string)
-      expect(dashed).to eq 'H-e-l-l-o-W-h-o-Are'
+      expect(dashed).to eq 'H-e-l-l-o-W-h-o-A-r-e'
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe StoryBranch::StringUtils do
   describe 'normalised_branch_name' do
     it 'downcases the dashed string' do
       res = StoryBranch::StringUtils.normalised_branch_name(simple_string)
-      expect(res).to eq 'h-e-l-l-o-w-h-o-are'
+      expect(res).to eq 'h-e-l-l-o-w-h-o-a-r-e'
     end
   end
 


### PR DESCRIPTION
# Issue Title

- branch name sanitisation should also exclude back ticks

# Main changes

- gsub all non digit and alphabet characters with `-`

# Remove from here below if there is nothing to be added to the changelog
CHANGELOG
 - Fixes branch name sanitisation by ensuring that only digits and alphabet characters are part of the sanitised string
--- 8< ---
