### PR TITLE
[Resolves #83] Limit the branch name length

### DIFF
--- a/lib/story_branch/main.rb
+++ b/lib/story_branch/main.rb
@@ -173,6 +173,7 @@ module StoryBranch
       "[#{message_tag}] #{current_story.title}"
     end
 
+    # rubocop:disable Metrics/AbcSize
     def create_feature_branch(story)
       return if story.nil?
 
@@ -180,7 +181,7 @@ module StoryBranch
       prompt.say "You are checked out at: #{current_branch}"
       branch_name = prompt.ask('Provide a new branch name',
                                default: story.dashed_title)
-      feature_branch_name = branch_name.chomp
+      feature_branch_name = StringUtils.truncate(branch_name.chomp)
       return unless validate_branch_name(feature_branch_name, story.id)
 
       feature_branch_name_with_story_id = "#{feature_branch_name}-#{story.id}"
@@ -189,6 +190,7 @@ module StoryBranch
       # rubocop:enable Metrics/LineLength
       GitWrapper.create_branch feature_branch_name_with_story_id
     end
+    # rubocop:enable Metrics/AbcSize
 
     # Branch name validation
     def validate_branch_name(name, id)

--- a/lib/story_branch/string_utils.rb
+++ b/lib/story_branch/string_utils.rb
@@ -29,7 +29,7 @@ module StoryBranch
     def self.truncate(text, max_length = 40)
       return text if text.length <= max_length
 
-      text[0..max_length-1]
+      text[0..max_length - 1]
     end
   end
 end

--- a/lib/story_branch/string_utils.rb
+++ b/lib/story_branch/string_utils.rb
@@ -25,5 +25,11 @@ module StoryBranch
     def self.undashed(text)
       text.tr('-', ' ').squeeze(' ').strip.capitalize
     end
+
+    def self.truncate(text, max_length = 40)
+      return text if text.length <= max_length
+
+      text[0..max_length-1]
+    end
   end
 end

--- a/spec/unit/story_branch/main_spec.rb
+++ b/spec/unit/story_branch/main_spec.rb
@@ -163,9 +163,22 @@ RSpec.describe StoryBranch::Main do
 
       describe 'when the story id doesnt have a branch yet' do
         let(:branch_exists) { false }
-        it 'creates the branch for the feature based on the feature name' do
-          expect(StoryBranch::GitWrapper).to have_received(:create_branch)
-            .with(branch_name_with_id)
+        context 'when the branch name is not longer that 40 characters' do
+          it 'creates the branch for the feature based on the feature name' do
+            expect(StoryBranch::GitWrapper).to have_received(:create_branch)
+              .with(branch_name_with_id)
+          end
+        end
+
+        context 'when the branch name is longer than 40 characters' do
+          let(:branch_name) { '0123456789_0123456789_0123456789_0123456789' }
+          let(:branch_name_with_id) do
+            "#{StoryBranch::StringUtils.truncate(branch_name)}-#{story.id}"
+          end
+          it 'creates the branch for the feature based on the truncated name' do
+            expect(StoryBranch::GitWrapper).to have_received(:create_branch)
+              .with(branch_name_with_id)
+          end
         end
       end
 

--- a/spec/unit/string_utils_spec.rb
+++ b/spec/unit/string_utils_spec.rb
@@ -44,4 +44,24 @@ RSpec.describe StoryBranch::StringUtils do
       expect(res).to eq 'H e l l o w h o are'
     end
   end
+
+  describe 'truncate' do
+    it 'returns the original string if the length is less than max length' do
+      str = 'amazing bananas'
+      res = StoryBranch::StringUtils.truncate(str)
+      expect(res).to eq str
+    end
+
+    it 'returns the original string if the length is less than max length' do
+      str = 'amazing bananas'
+      res = StoryBranch::StringUtils.truncate(str, str.length)
+      expect(res).to eq str
+    end
+
+    it 'returns the truncated string if the length is greater than max' do
+      str = 'amazing bananas'
+      res = StoryBranch::StringUtils.truncate(str, 7)
+      expect(res).to eq 'amazing'
+    end
+  end
 end


### PR DESCRIPTION
# Issue Title

- Limit the branch name length

# Main changes

- Created truncate method in string utils
- Calling truncate method for branch name