### PR TITLE
[Resolves #79] Support Order for branch name

### DIFF
--- a/lib/story_branch/main.rb
+++ b/lib/story_branch/main.rb
@@ -174,7 +174,8 @@ module StoryBranch
       fallback = @global_config.fetch(project_id,
                                       :issue_placement,
                                       default: 'End')
-      @issue_placement = @local_config.fetch(:issue_placement, default: fallback)
+      @issue_placement = @local_config.fetch(:issue_placement,
+                                             default: fallback)
       @issue_placement
     end
 
@@ -184,6 +185,7 @@ module StoryBranch
     end
 
     # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
     def create_feature_branch(story)
       return if story.nil?
 
@@ -203,6 +205,7 @@ module StoryBranch
       GitWrapper.create_branch feature_branch_name_with_story_id
     end
     # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength
 
     def build_branch_name(branch_name, story_id)
       if issue_placement.casecmp('beginning').zero?

--- a/lib/story_branch/main.rb
+++ b/lib/story_branch/main.rb
@@ -168,6 +168,16 @@ module StoryBranch
       @finish_tag
     end
 
+    def issue_placement
+      return @issue_placement if @issue_placement
+
+      fallback = @global_config.fetch(project_id,
+                                      :issue_placement,
+                                      default: 'End')
+      @issue_placement = @local_config.fetch(:issue_placement, default: fallback)
+      @issue_placement
+    end
+
     def build_finish_message
       message_tag = [finish_tag, "##{current_story.id}"].join(' ').strip
       "[#{message_tag}] #{current_story.title}"
@@ -184,13 +194,23 @@ module StoryBranch
       feature_branch_name = StringUtils.truncate(branch_name.chomp)
       return unless validate_branch_name(feature_branch_name, story.id)
 
-      feature_branch_name_with_story_id = "#{feature_branch_name}-#{story.id}"
+      feature_branch_name_with_story_id = build_branch_name(
+        feature_branch_name, story.id
+      )
       # rubocop:disable Metrics/LineLength
       prompt.say("Creating: #{feature_branch_name_with_story_id} with #{current_branch} as parent")
       # rubocop:enable Metrics/LineLength
       GitWrapper.create_branch feature_branch_name_with_story_id
     end
     # rubocop:enable Metrics/AbcSize
+
+    def build_branch_name(branch_name, story_id)
+      if issue_placement.casecmp('beginning').zero?
+        "#{story_id}-#{branch_name}"
+      else
+        "#{branch_name}-#{story_id}"
+      end
+    end
 
     # Branch name validation
     def validate_branch_name(name, id)

--- a/spec/unit/story_branch/main_spec.rb
+++ b/spec/unit/story_branch/main_spec.rb
@@ -163,6 +163,22 @@ RSpec.describe StoryBranch::Main do
 
       describe 'when the story id doesnt have a branch yet' do
         let(:branch_exists) { false }
+
+        context 'settings set issue id to be in the beginning' do
+          let(:local_config) do
+            conf = ::TTY::Config.new
+            conf.set('project_id', value: '123456')
+            conf.set('issue_placement', value: 'beginning')
+            conf
+          end
+          let(:branch_name_with_id) { "#{story.id}-#{branch_name}" }
+
+          it 'creates the branch for the feature based on the feature name' do
+            expect(StoryBranch::GitWrapper).to have_received(:create_branch)
+              .with(branch_name_with_id)
+          end
+        end
+
         context 'when the branch name is not longer that 40 characters' do
           it 'creates the branch for the feature based on the feature name' do
             expect(StoryBranch::GitWrapper).to have_received(:create_branch)


### PR DESCRIPTION
# Issue Title

- Support Order for branch name

# Main changes

- Added ability to parse issue placement from settings and using it to decide where to place the issue number in the branch name. It expects either `beginning` or `end` and defaults to end.

# Remove from here below if there is nothing to be added to the changelog
CHANGELOG
 - Added support for issue placement in the settings
--- 8< ---
