### PR TITLE
[Resolves #74] Similar branch name error is too opinionated

### DIFF
--- a/lib/story_branch/git_utils.rb
+++ b/lib/story_branch/git_utils.rb
@@ -7,7 +7,7 @@ module StoryBranch
   # Class used to interact with git. It relies on git gem as the wrapper
   # and levenshtein algo to determine branch name proximity
   class GitUtils
-    def self.existing_branch?(name)
+    def self.similar_branch?(name)
       GitWrapper.branch_names.each do |n|
         return true if DamerauLevenshtein.distance(n, name) < 3
 

--- a/lib/story_branch/main.rb
+++ b/lib/story_branch/main.rb
@@ -221,11 +221,18 @@ module StoryBranch
         prompt.error("An existing branch has the same story id: #{id}")
         return false
       end
-      if GitUtils.existing_branch? name
-        # rubocop:disable Layout/LineLength
-        prompt.error('This name is very similar to an existing branch. Avoid confusion and use a more unique name.')
-        # rubocop:enable Layout/LineLength
-        return false
+      if GitUtils.similar_branch? name
+        prompt.warn('This name is very similar to an existing branch. It is recommended to use a more unique name.')
+        decision = prompt.select('What to do?') do |menu|
+          menu.choice 'Rename the branch', 1
+          menu.choice 'Proceed with branch name', 2
+          menu.choice 'Abort branch creation', 3
+        end
+        return false if decision == 3
+        return true if decision == 2
+
+        branch_name = prompt.ask('Provide a new branch name',
+                                 default: story.dashed_title)
       end
       true
     end

--- a/lib/story_branch/main.rb
+++ b/lib/story_branch/main.rb
@@ -7,6 +7,10 @@ require_relative './git_utils'
 require_relative './git_wrapper'
 require_relative './config_manager'
 require 'tty-prompt'
+require 'pry'
+
+Pry.config.history.should_load = false
+Pry.config.history.should_save = false
 
 module StoryBranch
   # Main story branch class. It is responsible for the main interaction between
@@ -204,7 +208,6 @@ module StoryBranch
     end
 
     def valid_branch_name(story)
-      current_branch = GitWrapper.current_branch
       prompt.say "You are checked out at: #{current_branch}"
       branch_name = prompt.ask('Provide a new branch name',
                                default: story.dashed_title)
@@ -258,6 +261,10 @@ module StoryBranch
 
     def username
       @username ||= @global_config.fetch(project_id, :username)
+    end
+
+    def current_branch
+      @current_branch ||= GitWrapper.current_branch
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/lib/story_branch/main.rb
+++ b/lib/story_branch/main.rb
@@ -7,10 +7,6 @@ require_relative './git_utils'
 require_relative './git_wrapper'
 require_relative './config_manager'
 require 'tty-prompt'
-require 'pry'
-
-Pry.config.history.should_load = false
-Pry.config.history.should_save = false
 
 module StoryBranch
   # Main story branch class. It is responsible for the main interaction between

--- a/lib/story_branch/main.rb
+++ b/lib/story_branch/main.rb
@@ -195,9 +195,8 @@ module StoryBranch
       branch_name = valid_branch_name(story)
       return unless branch_name
 
+      # rubocop:disable Layout/LineLength
       feature_branch_name_with_story_id = build_branch_name(branch_name, story.id)
-
-      # rubocop:disable Metrics/LineLength
       prompt.say("Creating: #{feature_branch_name_with_story_id} with #{current_branch} as parent")
       # rubocop:enable Layout/LineLength
       GitWrapper.create_branch feature_branch_name_with_story_id
@@ -213,9 +212,11 @@ module StoryBranch
     end
 
     # Branch name validation
+    # rubocop:disable Metrics/MethodLength
     def validate_branch_name(name)
       if GitUtils.similar_branch? name
-        prompt.warn('This name is very similar to an existing branch. It is recommended to use a more unique name.')
+        prompt.warn('This name is very similar to an existing branch.'\
+                    ' It is recommended to use a more unique name.')
         decision = prompt.select('What to do?') do |menu|
           menu.choice 'Rename the branch', 1
           menu.choice 'Proceed with branch name', 2
@@ -228,6 +229,7 @@ module StoryBranch
       end
       name
     end
+    # rubocop:enable Metrics/MethodLength
 
     def build_branch_name(branch_name, story_id)
       if issue_placement.casecmp('beginning').zero?

--- a/lib/story_branch/main.rb
+++ b/lib/story_branch/main.rb
@@ -184,43 +184,37 @@ module StoryBranch
       "[#{message_tag}] #{current_story.title}"
     end
 
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def create_feature_branch(story)
       return if story.nil?
 
+      if GitUtils.branch_for_story_exists? story.id
+        prompt.error("An existing branch has the same story id: #{story.id}")
+        return
+      end
+
+      branch_name = valid_branch_name(story)
+      return unless branch_name
+
+      feature_branch_name_with_story_id = build_branch_name(branch_name, story.id)
+
+      # rubocop:disable Metrics/LineLength
+      prompt.say("Creating: #{feature_branch_name_with_story_id} with #{current_branch} as parent")
+      # rubocop:enable Layout/LineLength
+      GitWrapper.create_branch feature_branch_name_with_story_id
+    end
+
+    def valid_branch_name(story)
       current_branch = GitWrapper.current_branch
       prompt.say "You are checked out at: #{current_branch}"
       branch_name = prompt.ask('Provide a new branch name',
                                default: story.dashed_title)
       feature_branch_name = StringUtils.truncate(branch_name.chomp)
-      return unless validate_branch_name(feature_branch_name, story.id)
 
-      feature_branch_name_with_story_id = build_branch_name(
-        feature_branch_name, story.id
-      )
-      # rubocop:disable Layout/LineLength
-      prompt.say("Creating: #{feature_branch_name_with_story_id} with #{current_branch} as parent")
-      # rubocop:enable Layout/LineLength
-      GitWrapper.create_branch feature_branch_name_with_story_id
-    end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
-
-    def build_branch_name(branch_name, story_id)
-      if issue_placement.casecmp('beginning').zero?
-        "#{story_id}-#{branch_name}"
-      else
-        "#{branch_name}-#{story_id}"
-      end
+      validate_branch_name(feature_branch_name)
     end
 
     # Branch name validation
-    def validate_branch_name(name, id)
-      if GitUtils.branch_for_story_exists? id
-        prompt.error("An existing branch has the same story id: #{id}")
-        return false
-      end
+    def validate_branch_name(name)
       if GitUtils.similar_branch? name
         prompt.warn('This name is very similar to an existing branch. It is recommended to use a more unique name.')
         decision = prompt.select('What to do?') do |menu|
@@ -228,13 +222,20 @@ module StoryBranch
           menu.choice 'Proceed with branch name', 2
           menu.choice 'Abort branch creation', 3
         end
-        return false if decision == 3
-        return true if decision == 2
+        return nil if decision == 3
+        return name if decision == 2
 
-        branch_name = prompt.ask('Provide a new branch name',
-                                 default: story.dashed_title)
+        return prompt.ask('Provide a new branch name', default: name)
       end
-      true
+      name
+    end
+
+    def build_branch_name(branch_name, story_id)
+      if issue_placement.casecmp('beginning').zero?
+        "#{story_id}-#{branch_name}"
+      else
+        "#{branch_name}-#{story_id}"
+      end
     end
 
     def project_id

--- a/spec/unit/story_branch/git_utils_spec.rb
+++ b/spec/unit/story_branch/git_utils_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe StoryBranch::GitUtils do
     allow(DamerauLevenshtein).to receive(:distance).and_return(*distances)
   end
 
-  describe 'existing_branch?' do
+  describe 'similar_branch?' do
     it 'determnines levenshtein distance between branch name and branch list' do
-      StoryBranch::GitUtils.existing_branch?('new-branch-name')
+      StoryBranch::GitUtils.similar_branch?('new-branch-name')
       expect(DamerauLevenshtein).to have_received(:distance)
         .with('amazing-name-1', 'new-branch-name')
       expect(DamerauLevenshtein).to have_received(:distance)
@@ -31,14 +31,14 @@ RSpec.describe StoryBranch::GitUtils do
       let(:distances) { [3, 4, 3, 4] }
 
       it 'returns false' do
-        expect(StoryBranch::GitUtils.existing_branch?('new-branch')).to eq false
+        expect(StoryBranch::GitUtils.similar_branch?('new-branch')).to eq false
       end
     end
 
     describe 'when levenshtein distance is close' do
       let(:distances) { [2] }
       it 'returns false' do
-        expect(StoryBranch::GitUtils.existing_branch?('new-branch')).to eq true
+        expect(StoryBranch::GitUtils.similar_branch?('new-branch')).to eq true
       end
     end
   end

--- a/spec/unit/story_branch/lib/github/project_spec.rb
+++ b/spec/unit/story_branch/lib/github/project_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe StoryBranch::Github::Project do
   describe 'stories' do
     let(:blanket_project) { double('project') }
     let(:project) { described_class.new(blanket_project) }
-    let(:issues_double) { double('issues', get: matching_issue) }
+    let(:get_double) { OpenStruct.new(payload: matching_issue) }
+    let(:issues_double) { double('issues', get: get_double) }
     let(:matching_issue) { OpenStruct.new(title: 'Issue', pull_request: false) }
 
     before do

--- a/spec/unit/story_branch/main_spec.rb
+++ b/spec/unit/story_branch/main_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe StoryBranch::Main do
     allow(StoryBranch::GitUtils).to receive_messages(
       current_branch_story_parts: branch_story_parts,
       branch_for_story_exists?: branch_exists,
-      existing_branch?: similar_branch
+      similar_branch?: similar_branch
     )
     allow(StoryBranch::GitWrapper).to receive_messages(
       create_branch: true,

--- a/spec/unit/story_branch/main_spec.rb
+++ b/spec/unit/story_branch/main_spec.rb
@@ -221,14 +221,29 @@ RSpec.describe StoryBranch::Main do
       describe 'when branch name is very similar to an exsiting one' do
         let(:similar_branch) { true }
 
-        it 'does not create a new branch' do
-          expect(StoryBranch::GitWrapper).to_not have_received(:create_branch)
-        end
-
         it 'shows an informative message' do
           message = 'This name is very similar to an existing branch. '\
           'It is recommended to use a more unique name.'
           expect(prompt).to have_received(:warn).with(message)
+        end
+
+        context 'when the user aborts the creation of the branch' do
+          # NOTE: User selects abort
+          let(:similar_branch_option) { 3 }
+
+          it 'does not create a new branch' do
+            expect(StoryBranch::GitWrapper).to_not have_received(:create_branch)
+          end
+        end
+
+        context 'when the user decides to proceed with the branch creation' do
+          # NOTE: User selects abort
+          let(:similar_branch_option) { 2 }
+
+          it 'does not create a new branch' do
+            expect(StoryBranch::GitWrapper).to have_received(:create_branch)
+              .with
+          end
         end
       end
     end

--- a/spec/unit/story_branch/main_spec.rb
+++ b/spec/unit/story_branch/main_spec.rb
@@ -240,7 +240,26 @@ RSpec.describe StoryBranch::Main do
           # NOTE: User selects proceed
           let(:similar_branch_option) { 2 }
 
-          it 'does not create a new branch' do
+          it 'creates the branch with the similar name' do
+            expect(StoryBranch::GitWrapper).to have_received(:create_branch)
+              .with(branch_name_with_id)
+          end
+        end
+
+        context 'when the user decides to rename the branch creation' do
+          # NOTE: User selects rename
+          let(:similar_branch_option) { 1 }
+
+          # NOTE: called twice because it has been called the first time
+          # before for collecting the name the first time
+          it 'asks the user for the new name' do
+            expect(prompt).to have_received(:ask).with(
+              'Provide a new branch name',
+              default: branch_name
+            ).twice
+          end
+
+          it 'creates the branch with the similar name' do
             expect(StoryBranch::GitWrapper).to have_received(:create_branch)
               .with(branch_name_with_id)
           end

--- a/spec/unit/story_branch/main_spec.rb
+++ b/spec/unit/story_branch/main_spec.rb
@@ -237,12 +237,12 @@ RSpec.describe StoryBranch::Main do
         end
 
         context 'when the user decides to proceed with the branch creation' do
-          # NOTE: User selects abort
+          # NOTE: User selects proceed
           let(:similar_branch_option) { 2 }
 
           it 'does not create a new branch' do
             expect(StoryBranch::GitWrapper).to have_received(:create_branch)
-              .with
+              .with(branch_name_with_id)
           end
         end
       end


### PR DESCRIPTION
# Issue Title

- Similar branch name error is too opinionated

# Main changes

- Updated flow to ask the user what to do when the branch name is too similar. This option provides 3 alternatives:
  a) Proceed with the 'too similar name'
  b) Rename
  c) Abort (old behavior)

# Remove from here below if there is nothing to be added to the changelog
CHANGELOG
 - If branch name is too similar ask the user what to do
--- 8< ---
