### PR TITLE
[Resolves #49] When a branch for a story id exists, instead of aborting, ask if you want to reopen

### DIFF
--- a/lib/story_branch/git_utils.rb
+++ b/lib/story_branch/git_utils.rb
@@ -20,15 +20,6 @@ module StoryBranch
       false
     end
 
-    def self.branch_for_story_exists?(id)
-      GitWrapper.branch_names.each do |n|
-        branch_id = n.match(/-[1-9]+[0-9]*$/)
-        next unless branch_id
-        return true if branch_id.to_s == "-#{id}"
-      end
-      false
-    end
-
     def self.branch_to_story_string(regex_matcher = /.*-(\d+$)/)
       GitWrapper.current_branch.match(regex_matcher)
     end

--- a/lib/story_branch/main.rb
+++ b/lib/story_branch/main.rb
@@ -163,11 +163,6 @@ module StoryBranch
     def create_feature_branch(story)
       return if story.nil?
 
-      if GitUtils.branch_for_story_exists? story.id
-        prompt.error("An existing branch has the same story id: #{story.id}")
-        return
-      end
-
       branch_name = valid_branch_name(story)
       return unless branch_name
 

--- a/spec/unit/story_branch/git_utils_spec.rb
+++ b/spec/unit/story_branch/git_utils_spec.rb
@@ -43,25 +43,6 @@ RSpec.describe StoryBranch::GitUtils do
     end
   end
 
-  describe 'branch_for_story_exists?' do
-    describe 'existing branches include the passed id' do
-      it 'fetches all branches with command execution' do
-        StoryBranch::GitUtils.branch_for_story_exists?(1)
-        expect(StoryBranch::GitWrapper).to have_received(:branch_names)
-      end
-
-      it 'returns true' do
-        expect(StoryBranch::GitUtils.branch_for_story_exists?(1)).to eq true
-      end
-    end
-
-    describe 'existing branches does not include the passed id' do
-      it 'returns false' do
-        expect(StoryBranch::GitUtils.branch_for_story_exists?(3)).to eq false
-      end
-    end
-  end
-
   describe 'branch_to_story_string' do
     let(:branch) { 'amazing-feature-1' }
 

--- a/spec/unit/story_branch/main_spec.rb
+++ b/spec/unit/story_branch/main_spec.rb
@@ -164,19 +164,6 @@ RSpec.describe StoryBranch::Main do
         end
       end
 
-      describe 'when the story id already has a branch' do
-        let(:branch_exists) { true }
-
-        it 'does not create a new branch' do
-          expect(StoryBranch::GitWrapper).to_not have_received(:create_branch)
-        end
-
-        it 'shows an informative message' do
-          message = "An existing branch has the same story id: #{story.id}"
-          expect(prompt).to have_received(:error).with(message)
-        end
-      end
-
       describe 'when branch name is very similar to an exsiting one' do
         let(:similar_branch) { true }
 


### PR DESCRIPTION
# Issue Title

- When a branch for a story id exists, instead of aborting, ask if you want to reopen

# Main changes

- Removed hard check for exact match on branch name. The flow already checks for name proximity, so exact match would raise the question to the user on what to do. This check has become redundant after having #74 

# Remove from here below if there is nothing to be added to the changelog
CHANGELOG
 - Removed exact match check when creating a branch that has a very similar name
--- 8< ---
