### PR TITLE
[Resolves #122] Allow support for username in the beginning

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby 2.7
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.7.x
     - name: Rubocop Linter
       uses: andrewmcodes/rubocop-linter-action@v0.1.2
       env:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -8,12 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7.x
+      uses: ruby/setup-ruby@v1
     - name: Rubocop Linter
-      uses: andrewmcodes/rubocop-linter-action@v0.1.2
+      uses: andrewmcodes/rubocop-linter-action@v3.3.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.story_branch.yml
+++ b/.story_branch.yml
@@ -1,5 +1,5 @@
 ---
-finish_tag: 'Resolves'
-tracker: 'github'
+finish_tag: Resolves
+tracker: github
 project_id:
 - story-branch/story_branch

--- a/lib/story_branch/config_manager.rb
+++ b/lib/story_branch/config_manager.rb
@@ -35,7 +35,7 @@ module StoryBranch
     end
 
     def branch_username
-      @branch_username ||= @config.fetch(:branch_username)
+      @branch_username ||= @config.fetch(project_key, :branch_username)
     end
 
     def finish_tag

--- a/lib/story_branch/config_manager.rb
+++ b/lib/story_branch/config_manager.rb
@@ -34,6 +34,10 @@ module StoryBranch
       @issue_placement ||= @config.fetch(:issue_placement, default: 'End')
     end
 
+    def branch_username
+      @branch_username ||= @config.fetch(:branch_username)
+    end
+
     def finish_tag
       @finish_tag ||= @config.fetch(project_key,
                                     :finish_tag, default: 'Finishes')

--- a/lib/story_branch/main.rb
+++ b/lib/story_branch/main.rb
@@ -196,11 +196,14 @@ module StoryBranch
     # rubocop:enable Metrics/MethodLength
 
     def build_branch_name(branch_name, story_id)
-      if @config.issue_placement.casecmp('beginning').zero?
-        "#{story_id}-#{branch_name}"
-      else
-        "#{branch_name}-#{story_id}"
-      end
+      branch_name = if @config.issue_placement.casecmp('beginning').zero?
+                      "#{story_id}-#{branch_name}"
+                    else
+                      "#{branch_name}-#{story_id}"
+                    end
+      return branch_name unless @config.branch_username
+
+      "#{@config.branch_username}/#{branch_name}"
     end
 
     def current_branch

--- a/spec/unit/story_branch/config_manager_spec.rb
+++ b/spec/unit/story_branch/config_manager_spec.rb
@@ -57,4 +57,26 @@ RSpec.describe StoryBranch::ConfigManager do
       expect(sb_config.finish_tag).to eq 'Finishes'
     end
   end
+
+  describe 'branch_username' do
+    it 'defaults to nil' do
+      expect(sb_config.branch_username).to eq nil
+    end
+
+    context 'when a value is set' do
+      let!(:global_config) do
+        FileUtils.mkdir_p Dir.home
+        conf = ::TTY::Config.new
+        conf.filename = '.story_branch'
+        conf.append_path Dir.home
+        conf.set('123456', 'api_key', value: 'myamazingkey')
+        conf.set('branch_username', value: 'zebananas')
+        conf.write(force: true)
+      end
+
+      it 'uses the value from the config' do
+        expect(sb_config.branch_username).to eq 'zebananas'
+      end
+    end
+  end
 end

--- a/spec/unit/story_branch/config_manager_spec.rb
+++ b/spec/unit/story_branch/config_manager_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe StoryBranch::ConfigManager do
         conf.filename = '.story_branch'
         conf.append_path Dir.home
         conf.set('123456', 'api_key', value: 'myamazingkey')
-        conf.set('branch_username', value: 'zebananas')
+        conf.set('123456', 'branch_username', value: 'zebananas')
         conf.write(force: true)
       end
 

--- a/spec/unit/story_branch/main_spec.rb
+++ b/spec/unit/story_branch/main_spec.rb
@@ -21,11 +21,13 @@ RSpec.describe StoryBranch::Main do
   let(:tracker_params) { { project_id: '123456', api_key: 'myamazingkey' } }
   let(:issue_placement) { 'end' }
   let(:finish_tag) { 'Finishes' }
+  let(:branch_username) { nil }
+  # TODO: This should generate the actual config and not use mocked instances
   let(:config) do
     instance_double(
       StoryBranch::ConfigManager,
       valid?: true, tracker_type: tracker_type, tracker_params: tracker_params,
-      issue_placement: issue_placement, finish_tag: finish_tag
+      issue_placement: issue_placement, finish_tag: finish_tag, branch_username: branch_username
     )
   end
   # NOTE: When prompting for what to do in case branch name is too similar,
@@ -209,6 +211,17 @@ RSpec.describe StoryBranch::Main do
             expect(StoryBranch::GitWrapper).to have_received(:create_branch)
               .with(branch_name_with_id)
           end
+        end
+      end
+
+      describe 'when the project is configured to have a branch username' do
+        let(:branch_username) { 'zebananas' }
+        let(:final_branch_name) { "#{branch_username}/#{branch_name_with_id}" }
+        # NOTE: User selects proceed
+        let(:similar_branch_option) { 2 }
+
+        it 'creates the branch prefixed by the branch username' do
+          expect(StoryBranch::GitWrapper).to have_received(:create_branch).with(final_branch_name)
         end
       end
     end


### PR DESCRIPTION
# Issue Title

- [Resolves #122] - Adds support for configuring a username to be used as prefix on branch name creation

# Main changes

- Adds configuration reading support. Configuration name is `branch_username` and defaults to nil
- If branch username is nil, nothing gets prefixed
- Updated the branch creation to make use of the branch username prefix if configured

# Remove from here below if there is nothing to be added to the changelog
CHANGELOG
 - Adds configuration reading support. Configuration name is `branch_username` and defaults to nil
 - If branch username is nil, nothing gets prefixed
--- 8< ---
