### PR TITLE
[#132] Linearapp graphql query should be using team key instead of name

### DIFF
--- a/lib/story_branch/linear_app/team.rb
+++ b/lib/story_branch/linear_app/team.rb
@@ -37,7 +37,7 @@ module StoryBranch
               }
             }
           }
-        )
+        ).squeeze
       end
     end
   end

--- a/lib/story_branch/linear_app/team.rb
+++ b/lib/story_branch/linear_app/team.rb
@@ -37,7 +37,7 @@ module StoryBranch
               }
             }
           }
-        ).squeeze
+        ).squeeze(' ')
       end
     end
   end

--- a/lib/story_branch/linear_app/team.rb
+++ b/lib/story_branch/linear_app/team.rb
@@ -26,7 +26,7 @@ module StoryBranch
         %(
           query Issue {
             viewer {
-              assignedIssues (filter: { team: { name: { eq: "#{@team_id}"} } }) {
+              assignedIssues (filter: { team: { key: { eq: "#{@team_id}"} } }) {
                 nodes {
                   id
                   title

--- a/spec/unit/story_branch/linear_app/team_spec.rb
+++ b/spec/unit/story_branch/linear_app/team_spec.rb
@@ -21,6 +21,24 @@ RSpec.describe StoryBranch::LinearApp::Team do
     })
   end
 
+  let(:expected_graphql_query) do
+    %(
+      query Issue {
+        viewer {
+          assignedIssues (filter: { team: { key: { eq: "#{team_key}"} } }) {
+            nodes {
+              id
+              title
+              description
+              number
+              url
+            }
+          }
+        }
+      }
+    ).squeeze
+  end
+
   before do
     allow(client).to receive(:get).and_return(stories)
   end
@@ -29,6 +47,8 @@ RSpec.describe StoryBranch::LinearApp::Team do
     it 'fetches the stories from graphql client' do
       team = described_class.new(team_key, client)
       stories = team.stories
+
+      expect(client).to have_received(:get).with(graphql_query: expected_graphql_query)
 
       expect(stories.length).to eq 1
       expect(stories[0].is_a?(StoryBranch::LinearApp::Issue)).to eq true

--- a/spec/unit/story_branch/linear_app/team_spec.rb
+++ b/spec/unit/story_branch/linear_app/team_spec.rb
@@ -9,20 +9,22 @@ RSpec.describe StoryBranch::LinearApp::Team do
   let(:team_key) { 'BAN' }
   let(:stories) do
     OpenStruct.new(data: {
-      'viewer' => {
-        'assignedIssues' => {
-          'nodes' => [
-            'title' => 'Hello',
-            'number' => '123123',
-            'url' => 'https://googl.e'
-          ]
-        }
-      }
-    })
+                     'viewer' => {
+                       'assignedIssues' => {
+                         'nodes' => [
+                           'title' => 'Hello',
+                           'number' => '123123',
+                           'url' => 'https://googl.e'
+                         ]
+                       }
+                     }
+                   })
   end
 
   let(:expected_graphql_query) do
+    # rubocop:disable Layout/LineLength
     "\n query Issue {\n viewer {\n assignedIssues (filter: { team: { key: { eq: \"BAN\"} } }) {\n nodes {\n id\n title\n description\n number\n url\n }\n }\n }\n }\n "
+    # rubocop:enable Layout/LineLength
   end
 
   before do

--- a/spec/unit/story_branch/linear_app/team_spec.rb
+++ b/spec/unit/story_branch/linear_app/team_spec.rb
@@ -22,21 +22,7 @@ RSpec.describe StoryBranch::LinearApp::Team do
   end
 
   let(:expected_graphql_query) do
-    %(
-      query Issue {
-        viewer {
-          assignedIssues (filter: { team: { key: { eq: "#{team_key}"} } }) {
-            nodes {
-              id
-              title
-              description
-              number
-              url
-            }
-          }
-        }
-      }
-    ).squeeze
+    "\n query Issue {\n viewer {\n assignedIssues (filter: { team: { key: { eq: \"BAN\"} } }) {\n nodes {\n id\n title\n description\n number\n url\n }\n }\n }\n }\n "
   end
 
   before do

--- a/spec/unit/story_branch/linear_app/team_spec.rb
+++ b/spec/unit/story_branch/linear_app/team_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'story_branch/graphql'
+require 'story_branch/linear_app/team'
+
+RSpec.describe StoryBranch::LinearApp::Team do
+  let(:client) { StoryBranch::Graphql::Client.new(api_url: 'https://api.linear.app/', api_key: '1231123') }
+  let(:team_key) { 'BAN' }
+  let(:stories) do
+    OpenStruct.new(data: {
+      'viewer' => {
+        'assignedIssues' => {
+          'nodes' => [
+            'title' => 'Hello',
+            'number' => '123123',
+            'url' => 'https://googl.e'
+          ]
+        }
+      }
+    })
+  end
+
+  before do
+    allow(client).to receive(:get).and_return(stories)
+  end
+
+  describe 'stories' do
+    it 'fetches the stories from graphql client' do
+      team = described_class.new(team_key, client)
+      stories = team.stories
+
+      expect(stories.length).to eq 1
+      expect(stories[0].is_a?(StoryBranch::LinearApp::Issue)).to eq true
+      expect(stories[0].to_s).to eq 'BAN-123123 - Hello'
+    end
+  end
+end


### PR DESCRIPTION
# Issue Title

- Resolves #132

# Main changes

- Update graphql string to filter by team key instead of team name
- Squeezes the graphql string
- Added test coverage for team graphql querying for stories

# Remove from here below if there is nothing to be added to the changelog
CHANGELOG
 - Sends graphql query squeezed (all extra whitespaces removed)
 - Filters the assigned tickets by team key instead of team name
--- 8< ---
